### PR TITLE
Add Laravel 12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Table of contents:
 | Locked Page |
 
 ### Requirements
-* [Laravel 5.3, 5.4, 5.5+ ,6+, 7+, 8+, 9+, 10+, and 11+](https://laravel.com/docs/installation)
+* [Laravel 5.3, 5.4, 5.5+ ,6+, 7+, 8+, 9+, 10+, 11+, and 12+](https://laravel.com/docs/installation)
 
 ### Installation Instructions
 1. From your projects root folder in terminal run:

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2",
-        "laravel/framework": "6.*|7.*|8.*|9.*|10.*|11.*"
+        "php": "^7.3|^8.0|^8.1|^8.2|^8.3",
+        "laravel/framework": "6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },
     "require-dev": {
-        "illuminate/support": "^8.5",
-        "laravel/laravel": "^8.0",
-        "laravel/tinker": "^2.4",
-        "orchestra/testbench": "^6.0",
+        "illuminate/support": "^8.5|^9.0|^10.0|^11.0|^12.0",
+        "laravel/laravel": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "laravel/tinker": "^2.4|^3.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "suin/phpcs-psr4-sniff": "^3.0"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,8 +10,8 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
+        <testsuite name="Package">
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
## Summary
- allow installation with Laravel Framework 12 and PHP 8.3
- expand dev tooling ranges and simplify PHPUnit test suite path
- document Laravel 12 support in README

## Testing
- `composer update`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68922aab1c08832abe604f0a9d92619a